### PR TITLE
Fix checking for the FileReader in Safari

### DIFF
--- a/build/libZoteroSingle.js
+++ b/build/libZoteroSingle.js
@@ -5141,7 +5141,8 @@ Zotero.file = {};
 
 Zotero.file.getFileInfo = function(file){
     //fileInfo: md5, filename, filesize, mtime, zip, contentType, charset
-    if(typeof FileReader != 'function'){
+    //
+    if(typeof FileReader === 'undefined'){
         return Promise.reject(new Error("FileReader not supported"));
     }
     

--- a/lib/js/File.js
+++ b/lib/js/File.js
@@ -2,7 +2,8 @@ Zotero.file = {};
 
 Zotero.file.getFileInfo = function(file){
     //fileInfo: md5, filename, filesize, mtime, zip, contentType, charset
-    if(typeof FileReader != 'function'){
+    //
+    if(typeof FileReader === 'undefined'){
         return Promise.reject(new Error("FileReader not supported"));
     }
     


### PR DESCRIPTION
This resolves an issue where Safari silently fails when selecting a file in the "Upload Attachment" dialog.